### PR TITLE
Resilient LLM model resolution under load

### DIFF
--- a/backend/app/api/cluster_resources.py
+++ b/backend/app/api/cluster_resources.py
@@ -1,6 +1,7 @@
 """Cluster resources API for real-time resource availability"""
 
 import asyncio
+import json
 import logging
 import time
 from typing import List, Dict, Any
@@ -27,8 +28,12 @@ router = APIRouter(prefix="/cluster", tags=["cluster-resources"])
 # instantly. _CACHE_TTL_SECONDS is the staleness threshold at which a *read*
 # triggers a background refresh, so the cache self-heals even if the loop isn't
 # running (e.g. in tests). _REFRESH_INTERVAL_SECONDS is the proactive cadence.
-_CACHE_TTL_SECONDS = 30
-_REFRESH_INTERVAL_SECONDS = 15
+# Cluster resource availability changes slowly, and each refresh deserialises
+# the whole pod list (CPU/GIL-bound). Refresh infrequently so the periodic
+# refresh doesn't repeatedly stall the event loop and starve latency-critical
+# in-memory endpoints like /llm/models/resolve under load.
+_CACHE_TTL_SECONDS = 120
+_REFRESH_INTERVAL_SECONDS = 60
 _cache: Dict[str, Any] = {"data": None, "updated_at": 0.0}
 _cache_lock = asyncio.Lock()
 _refreshing = False
@@ -145,14 +150,25 @@ def _compute_cluster_resources() -> List[Dict[str, Any]]:
     # Get all nodes
     nodes = v1.list_node()
 
-    # Fetch all pods ONCE and bucket by node. A per-node field_selector on
-    # spec.nodeName is not index-backed, so the API server re-lists every pod
-    # cluster-wide for each node (~3s each). One list + in-memory grouping keeps
-    # this endpoint fast.
-    all_pods = v1.list_pod_for_all_namespaces()
-    pods_by_node: Dict[str, List[Any]] = {}
-    for pod in all_pods.items:
-        pods_by_node.setdefault(pod.spec.node_name, []).append(pod)
+    # Fetch all pods ONCE and bucket by node.
+    #
+    # Two cost controls keep this from stalling the event loop (it runs every
+    # refresh and the deserialisation is CPU/GIL-bound even in a worker thread):
+    #   1. A single cluster-wide list (a per-node spec.nodeName field_selector is
+    #      not index-backed — the API server re-lists every pod per node).
+    #   2. `_preload_content=False` + manual JSON parse, so we DON'T construct a
+    #      typed V1Pod object graph for every pod (the dominant GIL cost); we read
+    #      only the few fields we need from plain dicts. A server-side phase
+    #      filter also drops terminated pods from the payload.
+    raw_pods = v1.list_pod_for_all_namespaces(
+        _preload_content=False,
+        field_selector="status.phase!=Succeeded,status.phase!=Failed",
+    )
+    pods_payload = json.loads(raw_pods.data)
+    pods_by_node: Dict[str, List[dict]] = {}
+    for pod in pods_payload.get("items", []):
+        node_of_pod = (pod.get("spec") or {}).get("nodeName")
+        pods_by_node.setdefault(node_of_pod, []).append(pod)
 
     result = []
     for node in nodes.items:
@@ -182,35 +198,36 @@ def _compute_cluster_resources() -> List[Dict[str, Any]]:
         allocated_memory = 0
         allocated_gpu = 0
 
+        # Terminated pods (Succeeded/Failed) are already excluded server-side via
+        # the field_selector above. Each pod is a plain dict (raw JSON).
         for pod in pods:
-            # Skip terminated pods
-            if pod.status.phase in ["Succeeded", "Failed"]:
-                continue
+            spec = pod.get("spec") or {}
+            for container in spec.get("containers", []):
+                limits = (container.get("resources") or {}).get("limits") or {}
+                if not limits:
+                    continue
 
-            for container in pod.spec.containers:
-                if container.resources:
-                    if container.resources.limits:
-                        # CPU
-                        cpu_limit = container.resources.limits.get("cpu", "0")
-                        if cpu_limit != "0":
-                            if cpu_limit.endswith('m'):
-                                allocated_cpu += int(cpu_limit[:-1]) / 1000
-                            else:
-                                try:
-                                    allocated_cpu += float(cpu_limit)
-                                except ValueError:
-                                    # Skip invalid CPU values like "512M" (probably memory)
-                                    pass
+                # CPU
+                cpu_limit = limits.get("cpu", "0")
+                if cpu_limit != "0":
+                    if cpu_limit.endswith('m'):
+                        allocated_cpu += int(cpu_limit[:-1]) / 1000
+                    else:
+                        try:
+                            allocated_cpu += float(cpu_limit)
+                        except ValueError:
+                            # Skip invalid CPU values like "512M" (probably memory)
+                            pass
 
-                        # Memory
-                        mem_limit = container.resources.limits.get("memory", "0")
-                        if mem_limit != "0":
-                            allocated_memory += parse_memory(mem_limit)
+                # Memory
+                mem_limit = limits.get("memory", "0")
+                if mem_limit != "0":
+                    allocated_memory += parse_memory(mem_limit)
 
-                        # GPU
-                        gpu_limit = container.resources.limits.get("nvidia.com/gpu", "0")
-                        if gpu_limit != "0":
-                            allocated_gpu += int(gpu_limit)
+                # GPU
+                gpu_limit = limits.get("nvidia.com/gpu", "0")
+                if gpu_limit != "0":
+                    allocated_gpu += int(gpu_limit)
 
         # Get GPU details if node has GPUs
         gpu_details = []

--- a/backend/app/api/llm/models_api.py
+++ b/backend/app/api/llm/models_api.py
@@ -92,6 +92,21 @@ async def list_models(
 
 
 @router.get(
+    "/resolve-all",
+    response_model=list[ModelResolveResponse],
+    operation_id="resolve_all_llm_models",
+)
+async def resolve_all_models():
+    """Bulk, in-memory dump of every resolvable model -> backend.
+
+    The Go proxy polls this on a timer and serves requests from a local
+    snapshot, so the inference hot path does not call the control plane per
+    request. In-memory only — no Kubernetes/network work on this path.
+    """
+    return llm_model_registry.resolve_all()
+
+
+@router.get(
     "/resolve",
     response_model=ModelResolveResponse,
     operation_id="resolve_llm_model",

--- a/backend/app/services/llm_model_registry.py
+++ b/backend/app/services/llm_model_registry.py
@@ -148,6 +148,22 @@ class LLMModelRegistry:
             tier=resolved_tier,
         )
 
+    def resolve_all(self) -> List[ModelResolveResponse]:
+        """In-memory dump of every currently-resolvable model -> backend.
+
+        Reuses :meth:`resolve` per model and keeps only the ones that resolved to
+        a healthy backend (have a ``backend_url`` and no error). Purely in-memory
+        (registry + backend-discovery state) — performs NO Kubernetes/network
+        call — so the Go proxy can poll it on a timer and resolve requests from a
+        local snapshot instead of calling the control plane per request.
+        """
+        out: List[ModelResolveResponse] = []
+        for model_id in list(self._models.keys()):
+            res = self.resolve(model_id)
+            if res and not res.error and res.backend_url:
+                out.append(res)
+        return out
+
     def _resolve_alias(self, alias: str) -> Optional[ModelEntry]:
         if alias in self._models:
             return self._models[alias]

--- a/backend/tests/test_cluster_resources_throttle.py
+++ b/backend/tests/test_cluster_resources_throttle.py
@@ -1,0 +1,62 @@
+"""cluster-resources refresh must not stall the event loop (SP-tgnbej SL-3).
+
+Deterministic structural checks (not flaky timing): the refresh is throttled and
+the pod fetch is offloaded + bounded, so it cannot block the resolve path.
+"""
+
+import json
+
+import app.api.cluster_resources as cr
+
+
+def test_refresh_cadence_is_throttled():
+    # An infrequent refresh means the periodic (CPU/GIL-bound) recompute can't
+    # repeatedly stall the loop.
+    assert cr._REFRESH_INTERVAL_SECONDS >= 60
+    assert cr._CACHE_TTL_SECONDS >= cr._REFRESH_INTERVAL_SECONDS
+
+
+class _FakeNodeList:
+    items: list = []
+
+
+class _FakeRaw:
+    data = json.dumps({"items": []})
+
+
+class _FakeV1:
+    def __init__(self):
+        self.pod_kwargs = None
+
+    def list_node(self):
+        return _FakeNodeList()
+
+    def list_pod_for_all_namespaces(self, **kwargs):
+        self.pod_kwargs = kwargs
+        return _FakeRaw()
+
+
+def test_compute_uses_bounded_lightweight_pod_fetch(monkeypatch):
+    fake = _FakeV1()
+    monkeypatch.setattr(cr.config, "load_incluster_config", lambda: None)
+    monkeypatch.setattr(cr.client, "CoreV1Api", lambda: fake)
+
+    result = cr._compute_cluster_resources()
+    assert result == []  # no nodes -> empty
+
+    # The pod list must avoid building a typed V1Pod object graph (the dominant
+    # GIL cost) and drop terminated pods server-side, so a refresh stays cheap.
+    assert fake.pod_kwargs is not None
+    assert fake.pod_kwargs.get("_preload_content") is False
+    fs = fake.pod_kwargs.get("field_selector", "")
+    assert "status.phase!=Succeeded" in fs
+    assert "status.phase!=Failed" in fs
+
+
+def test_refresh_is_offloaded_off_the_event_loop():
+    # _refresh_once must run the blocking compute via asyncio.to_thread, not on
+    # the event loop. Assert the source does exactly that.
+    import inspect
+
+    src = inspect.getsource(cr._refresh_once)
+    assert "to_thread" in src and "_compute_cluster_resources" in src

--- a/backend/tests/test_llm_resolve_all.py
+++ b/backend/tests/test_llm_resolve_all.py
@@ -1,0 +1,47 @@
+"""resolve_all(): in-memory bulk resolution for the proxy snapshot (SP-tgnbej SL-2)."""
+
+import app.services.llm_backend_discovery as disc_mod
+from app.api.llm.schemas import BackendEntry, ModelEntry, ModelState
+from app.services.llm_model_registry import LLMModelRegistry
+
+
+def test_resolve_all_returns_only_resolvable_models_in_memory(monkeypatch):
+    reg = LLMModelRegistry()
+    reg._models = {
+        "m-ok": ModelEntry(
+            id="m-ok", name="ok", server_type=["vllm"], serving_name="m-ok",
+            state=ModelState.available, backend_id="vllm-x",
+        ),
+        # deployable, not currently served -> must be excluded from the snapshot
+        "m-dep": ModelEntry(
+            id="m-dep", name="dep", server_type=["vllm"], state=ModelState.deployable,
+        ),
+    }
+
+    healthy = BackendEntry(
+        id="vllm-x", name="vllm-x", url="http://vllm:8000", type="vllm",
+        api_path="/v1", status="healthy", models=["m-ok"],
+    )
+    monkeypatch.setattr(
+        disc_mod.llm_backend_discovery, "get_backend",
+        lambda bid: healthy if bid == "vllm-x" else None,
+    )
+    monkeypatch.setattr(
+        disc_mod.llm_backend_discovery, "get_backends_serving",
+        lambda mid: [healthy] if mid == "m-ok" else [],
+    )
+
+    # AC5: the bulk path must not touch Kubernetes. Make any k8s client use blow up.
+    import kubernetes
+    def _boom(*_a, **_k):
+        raise AssertionError("resolve_all must not call Kubernetes")
+    monkeypatch.setattr(kubernetes.client, "CoreV1Api", _boom)
+
+    out = reg.resolve_all()
+
+    assert {r.model_id for r in out} == {"m-ok"}  # deployable/no-backend excluded
+    r = out[0]
+    assert r.backend_url == "http://vllm:8000"
+    assert r.api_path == "/v1"
+    assert r.serving_name == "m-ok"
+    assert r.error is None

--- a/docs/modules/ROOT/pages/llm-serving.adoc
+++ b/docs/modules/ROOT/pages/llm-serving.adoc
@@ -29,6 +29,32 @@ The "LLM gateway" is two cooperating pieces, not one:
 Clients only ever talk to the gateway; the control plane is what makes a model
 *be there* to talk to.
 
+== Request routing and resilience
+
+For every request the gateway resolves the requested model to a serving backend
+by asking the control plane. This resolution is hardened so that a momentary
+control-plane hiccup never looks like a missing model:
+
+* A successful resolution is cached briefly, and the gateway keeps the most
+  recent good resolution per model.
+* If a live resolution transiently fails — a timeout, a `5xx`, or a brief
+  "model is loading" / "no healthy backend" flap while the control plane
+  reconciles — the gateway retries once and, failing that, serves the
+  last-known-good resolution (a model-to-backend mapping is stable, so a
+  few-seconds-stale answer is correct).
+
+As a result the status codes are precise:
+
+[horizontal]
+`404 not found`:: the model is genuinely unknown to the catalog.
+`503 (retryable)`:: the model exists but is *temporarily* unresolvable (a
+  transient backend stall with no recent good resolution) — retry the request.
+
+A burst of concurrent requests to a loaded model therefore succeeds even if the
+control plane briefly stalls or flaps, instead of failing with a spurious
+`404 not found or not available`. The `llm_gateway_resolve_resilience_total`
+metric (labels `retry`, `stale_serve`) exposes how often these fallbacks fire.
+
 == Model lifecycle
 
 A model moves through these states:

--- a/docs/modules/ROOT/pages/llm-serving.adoc
+++ b/docs/modules/ROOT/pages/llm-serving.adoc
@@ -31,12 +31,20 @@ Clients only ever talk to the gateway; the control plane is what makes a model
 
 == Request routing and resilience
 
-For every request the gateway resolves the requested model to a serving backend
-by asking the control plane. This resolution is hardened so that a momentary
-control-plane hiccup never looks like a missing model:
+The gateway resolves the requested model to a serving backend from a
+*locally-synced snapshot* of the control plane's resolution table, refreshed in
+the background every few seconds. The inference hot path therefore resolves
+in-memory and does **not** call the control plane per request — a burst of
+requests to a loaded model is unaffected by control-plane load, stalls, or even
+a restart. The `llm_gateway_resolve_source_total` metric (labels `snapshot`,
+`live`) shows the split; a healthy system is overwhelmingly `snapshot`.
 
-* A successful resolution is cached briefly, and the gateway keeps the most
-  recent good resolution per model.
+Resolution is further hardened so a momentary control-plane hiccup never looks
+like a missing model:
+
+* A model not yet in the snapshot (e.g. just loaded) falls back to a single live
+  resolve call, and a successful live resolution is cached briefly with the most
+  recent good result kept per model.
 * If a live resolution transiently fails — a timeout, a `5xx`, or a brief
   "model is loading" / "no healthy backend" flap while the control plane
   reconciles — the gateway retries once and, failing that, serves the

--- a/proxy/internal/metrics/prometheus.go
+++ b/proxy/internal/metrics/prometheus.go
@@ -41,4 +41,13 @@ var (
 		Name: "llm_gateway_active_streams",
 		Help: "Currently active streaming connections",
 	}, []string{"protocol", "model"})
+
+	// ResolveResilience counts how often model resolution had to fall back on
+	// its resilience paths: "retry" (a transient backend failure was retried)
+	// and "stale_serve" (a transient failure was absorbed by serving the
+	// last-known-good resolution). A rising rate means the backend is flapping.
+	ResolveResilience = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "llm_gateway_resolve_resilience_total",
+		Help: "Model-resolution resilience fallbacks (retry / stale_serve)",
+	}, []string{"event"})
 )

--- a/proxy/internal/metrics/prometheus.go
+++ b/proxy/internal/metrics/prometheus.go
@@ -50,4 +50,14 @@ var (
 		Name: "llm_gateway_resolve_resilience_total",
 		Help: "Model-resolution resilience fallbacks (retry / stale_serve)",
 	}, []string{"event"})
+
+	// ResolveSource counts model resolutions by source: "snapshot" (served from
+	// the locally-synced registry snapshot, no control-plane call) vs "live" (a
+	// per-request call to the control plane, on a snapshot miss). A healthy
+	// system is overwhelmingly "snapshot" — a high "live" rate means the hot
+	// path is still hitting the control plane per request.
+	ResolveSource = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "llm_gateway_resolve_source_total",
+		Help: "Model resolutions by source (snapshot hit vs live control-plane call)",
+	}, []string{"source"})
 )

--- a/proxy/internal/resolver/resolver.go
+++ b/proxy/internal/resolver/resolver.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/thinkube/thinkube-control/proxy/internal/metrics"
@@ -44,6 +45,13 @@ type Resolver struct {
 	cacheTTL    time.Duration
 	lastGoodTTL time.Duration
 	retryDelay  time.Duration
+
+	// snapshot is a locally-synced copy of the control plane's whole resolution
+	// table (keyed by model id AND serving name), refreshed in the background by
+	// StartSnapshotSync. Resolve serves tier-agnostic requests from it without
+	// any per-request control-plane call; a miss falls back to the live path.
+	snapshot     atomic.Pointer[map[string]*ResolveResult]
+	syncInterval time.Duration
 }
 
 func New(backendURL string, aliases map[string]string) *Resolver {
@@ -60,6 +68,11 @@ func New(backendURL string, aliases map[string]string) *Resolver {
 		// long-gone backend.
 		lastGoodTTL: 5 * time.Minute,
 		retryDelay:  150 * time.Millisecond,
+		// How often the background snapshot is refreshed from the control plane.
+		// The resolution table changes on the order of minutes (model loads), so
+		// a few seconds keeps it fresh while reducing control-plane traffic from
+		// per-request to ~one poll per interval.
+		syncInterval: 5 * time.Second,
 	}
 }
 
@@ -77,6 +90,19 @@ func (r *Resolver) Resolve(ctx context.Context, model string, tier string) (*Res
 		model = alias
 	}
 
+	// Snapshot-first: serve tier-agnostic requests from the locally-synced
+	// table with no control-plane call. Tier-specific requests skip the snapshot
+	// (it holds each model's default-tier resolution) and take the live path,
+	// which honours tier.
+	if tier == "" {
+		if snap := r.snapshot.Load(); snap != nil {
+			if res, ok := (*snap)[model]; ok {
+				metrics.ResolveSource.WithLabelValues("snapshot").Inc()
+				return res, nil
+			}
+		}
+	}
+
 	cacheKey := model + ":" + tier
 
 	// Fresh cache hit.
@@ -88,7 +114,9 @@ func (r *Resolver) Resolve(ctx context.Context, model string, tier string) (*Res
 		r.cache.Delete(cacheKey)
 	}
 
-	// Live fetch, with one retry on a transient failure.
+	// Live fetch (snapshot miss or tier-specific), with one retry on a transient
+	// failure.
+	metrics.ResolveSource.WithLabelValues("live").Inc()
 	result, err := r.fetch(ctx, model, tier)
 	if err != nil && !errors.Is(err, ErrModelNotFound) {
 		metrics.ResolveResilience.WithLabelValues("retry").Inc()
@@ -173,4 +201,67 @@ func (r *Resolver) fetch(ctx context.Context, model, tier string) (*ResolveResul
 	}
 
 	return &result, nil
+}
+
+// StartSnapshotSync launches a background goroutine that refreshes the local
+// resolution snapshot from the control plane's bulk endpoint every syncInterval,
+// so Resolve serves requests without a per-request control-plane call. It does
+// an immediate load, then ticks until ctx is cancelled.
+func (r *Resolver) StartSnapshotSync(ctx context.Context) {
+	go func() {
+		if err := r.loadSnapshot(ctx); err != nil {
+			slog.Warn("initial resolve-all snapshot load failed", "error", err)
+		}
+		t := time.NewTicker(r.syncInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := r.loadSnapshot(ctx); err != nil {
+					slog.Warn("resolve-all snapshot refresh failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// loadSnapshot fetches the control plane's full resolution table once and
+// atomically swaps it in, keyed by both model id and serving name.
+func (r *Resolver) loadSnapshot(ctx context.Context) error {
+	reqURL := r.backendURL + "/api/v1/llm/models/resolve-all"
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create resolve-all request: %w", err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resolve-all request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("resolve-all returned %d", resp.StatusCode)
+	}
+
+	var items []ResolveResult
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return fmt.Errorf("decode resolve-all response: %w", err)
+	}
+
+	m := make(map[string]*ResolveResult, len(items)*2)
+	for i := range items {
+		res := &items[i]
+		if res.ModelID != "" {
+			m[res.ModelID] = res
+		}
+		if res.ServingName != "" {
+			m[res.ServingName] = res
+		}
+	}
+	r.snapshot.Store(&m)
+	slog.Debug("resolve-all snapshot refreshed", "models", len(items))
+	return nil
 }

--- a/proxy/internal/resolver/resolver.go
+++ b/proxy/internal/resolver/resolver.go
@@ -3,13 +3,22 @@ package resolver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/thinkube/thinkube-control/proxy/internal/metrics"
 )
+
+// ErrModelNotFound is the definitive "this model is unknown" signal from the
+// backend (HTTP 404). It is the ONLY resolve failure that should surface to the
+// client as 404 — every other failure (timeout, 5xx, transient 400 state/health
+// flap) is transient and must be treated as retryable, never as not-found.
+var ErrModelNotFound = errors.New("model not found")
 
 type ResolveResult struct {
 	BackendURL  string `json:"backend_url"`
@@ -27,11 +36,14 @@ type cacheEntry struct {
 }
 
 type Resolver struct {
-	backendURL string
-	aliases    map[string]string
-	client     *http.Client
-	cache      sync.Map
-	cacheTTL   time.Duration
+	backendURL  string
+	aliases     map[string]string
+	client      *http.Client
+	cache       sync.Map // cacheKey -> *cacheEntry (fresh, short TTL)
+	lastGood    sync.Map // cacheKey -> *cacheEntry (last successful, longer TTL)
+	cacheTTL    time.Duration
+	lastGoodTTL time.Duration
+	retryDelay  time.Duration
 }
 
 func New(backendURL string, aliases map[string]string) *Resolver {
@@ -42,6 +54,12 @@ func New(backendURL string, aliases map[string]string) *Resolver {
 			Timeout: 5 * time.Second,
 		},
 		cacheTTL: 10 * time.Second,
+		// A model -> backend mapping is stable, so a recently-successful
+		// resolution is safe to reuse for a short window when the backend is
+		// momentarily unreachable/flapping. Bounded so we never route to a
+		// long-gone backend.
+		lastGoodTTL: 5 * time.Minute,
+		retryDelay:  150 * time.Millisecond,
 	}
 }
 
@@ -49,14 +67,19 @@ func (r *Resolver) BackendURL() string {
 	return r.backendURL
 }
 
+// Resolve maps a model alias/id to a backend. On a transient backend failure it
+// retries once and, failing that, serves the last-known-good resolution within
+// lastGoodTTL — so a momentary backend stall/flap does not surface as a 404.
+// Only a definitive not-found (ErrModelNotFound) is returned without fallback.
 func (r *Resolver) Resolve(ctx context.Context, model string, tier string) (*ResolveResult, error) {
 	if alias, ok := r.aliases[model]; ok {
 		slog.Debug("model alias resolved", "from", model, "to", alias)
 		model = alias
 	}
 
-	// Check cache first
 	cacheKey := model + ":" + tier
+
+	// Fresh cache hit.
 	if entry, ok := r.cache.Load(cacheKey); ok {
 		ce := entry.(*cacheEntry)
 		if time.Now().Before(ce.expiresAt) {
@@ -65,6 +88,50 @@ func (r *Resolver) Resolve(ctx context.Context, model string, tier string) (*Res
 		r.cache.Delete(cacheKey)
 	}
 
+	// Live fetch, with one retry on a transient failure.
+	result, err := r.fetch(ctx, model, tier)
+	if err != nil && !errors.Is(err, ErrModelNotFound) {
+		metrics.ResolveResilience.WithLabelValues("retry").Inc()
+		slog.Warn("resolve transient failure, retrying", "model", model, "error", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(r.retryDelay):
+		}
+		result, err = r.fetch(ctx, model, tier)
+	}
+
+	if err == nil {
+		r.cache.Store(cacheKey, &cacheEntry{result: result, expiresAt: time.Now().Add(r.cacheTTL)})
+		r.lastGood.Store(cacheKey, &cacheEntry{result: result, expiresAt: time.Now().Add(r.lastGoodTTL)})
+		return result, nil
+	}
+
+	// Definitive not-found: the model is genuinely unknown — do NOT serve stale.
+	if errors.Is(err, ErrModelNotFound) {
+		return nil, err
+	}
+
+	// Transient failure: absorb it with the last-known-good resolution if we
+	// have a recent one.
+	if entry, ok := r.lastGood.Load(cacheKey); ok {
+		ce := entry.(*cacheEntry)
+		if time.Now().Before(ce.expiresAt) {
+			metrics.ResolveResilience.WithLabelValues("stale_serve").Inc()
+			slog.Warn("resolve transient failure, serving last-known-good",
+				"model", model, "error", err)
+			return ce.result, nil
+		}
+		r.lastGood.Delete(cacheKey)
+	}
+
+	return nil, err
+}
+
+// fetch performs one resolve call against the backend and classifies the
+// outcome. A backend 404 becomes ErrModelNotFound (definitive); every other
+// error path is transient (retryable / stale-eligible).
+func (r *Resolver) fetch(ctx context.Context, model, tier string) (*ResolveResult, error) {
 	params := url.Values{}
 	params.Set("model", model)
 	if tier != "" {
@@ -79,35 +146,31 @@ func (r *Resolver) Resolve(ctx context.Context, model string, tier string) (*Res
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("resolve request failed: %w", err)
+		return nil, fmt.Errorf("resolve request failed: %w", err) // transient
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("model not found: %s", model)
+		return nil, fmt.Errorf("%w: %s", ErrModelNotFound, model) // definitive
 	}
 
 	var result ResolveResult
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode resolve response: %w", err)
+		return nil, fmt.Errorf("decode resolve response: %w", err) // transient
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// Non-200, non-404: a state/health flap (e.g. "Model is loading", "No
+		// healthy backend serving model"). Transient — retry / serve stale.
 		if result.Error != "" {
-			return nil, fmt.Errorf("%s", result.Error)
+			return nil, fmt.Errorf("resolve returned %d: %s", resp.StatusCode, result.Error)
 		}
 		return nil, fmt.Errorf("resolve returned %d", resp.StatusCode)
 	}
 
 	if result.Error != "" {
-		return &result, fmt.Errorf("%s", result.Error)
+		return &result, fmt.Errorf("%s", result.Error) // transient
 	}
-
-	// Cache successful result
-	r.cache.Store(cacheKey, &cacheEntry{
-		result:    &result,
-		expiresAt: time.Now().Add(r.cacheTTL),
-	})
 
 	return &result, nil
 }

--- a/proxy/internal/resolver/resolver_test.go
+++ b/proxy/internal/resolver/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -127,5 +128,84 @@ func TestResolveRetryThenSucceed(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Fatalf("backend calls = %d, want 2 (one retry)", got)
+	}
+}
+
+// resolveAllBody returns a one-model resolve-all payload.
+func resolveAllBody(modelID, servingName string) string {
+	return `[{"backend_url":"http://b","api_path":"/v1","model_id":"` + modelID +
+		`","serving_name":"` + servingName + `","model_state":"available","tier":"performance"}]`
+}
+
+// With a populated snapshot, concurrent requests for a snapshotted model resolve
+// in-memory and make ZERO per-request control-plane (/resolve) calls.
+func TestSnapshotHitAvoidsLiveCall(t *testing.T) {
+	var liveCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/llm/models/resolve-all", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(resolveAllBody("m", "m-serve")))
+	})
+	mux.HandleFunc("/api/v1/llm/models/resolve", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&liveCalls, 1)
+		w.Write([]byte(okBody("m")))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	if err := r.loadSnapshot(context.Background()); err != nil {
+		t.Fatalf("snapshot load: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := "m"
+			if i%2 == 0 {
+				key = "m-serve" // resolvable by serving name too
+			}
+			res, err := r.Resolve(context.Background(), key, "")
+			if err != nil || res == nil || res.ModelID != "m" {
+				t.Errorf("resolve(%q): res=%v err=%v", key, res, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&liveCalls); got != 0 {
+		t.Fatalf("live /resolve calls = %d, want 0 (served from snapshot)", got)
+	}
+}
+
+// A model absent from the snapshot falls back to exactly one live /resolve call.
+func TestSnapshotMissFallsBackToLive(t *testing.T) {
+	var liveCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/llm/models/resolve-all", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(resolveAllBody("known", "known")))
+	})
+	mux.HandleFunc("/api/v1/llm/models/resolve", func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&liveCalls, 1)
+		w.Write([]byte(okBody(req.URL.Query().Get("model"))))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	if err := r.loadSnapshot(context.Background()); err != nil {
+		t.Fatalf("snapshot load: %v", err)
+	}
+
+	res, err := r.Resolve(context.Background(), "fresh-model", "")
+	if err != nil {
+		t.Fatalf("expected live fallback success, got: %v", err)
+	}
+	if res.ModelID != "fresh-model" {
+		t.Fatalf("model_id = %q, want fresh-model", res.ModelID)
+	}
+	if got := atomic.LoadInt32(&liveCalls); got != 1 {
+		t.Fatalf("live /resolve calls = %d, want 1 (snapshot miss -> one live resolve)", got)
 	}
 }

--- a/proxy/internal/resolver/resolver_test.go
+++ b/proxy/internal/resolver/resolver_test.go
@@ -1,0 +1,131 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func newTestResolver(url string) *Resolver {
+	r := New(url, nil)
+	r.retryDelay = 0 // no backoff in tests
+	return r
+}
+
+func okBody(model string) string {
+	return `{"backend_url":"http://b","api_path":"/v1","model_id":"` + model +
+		`","serving_name":"` + model + `","model_state":"available","tier":"performance"}`
+}
+
+// A successful resolve is cached: repeated calls hit the backend once.
+func TestResolveSuccessCaches(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Write([]byte(okBody("m")))
+	}))
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	for i := 0; i < 3; i++ {
+		res, err := r.Resolve(context.Background(), "m", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.ModelID != "m" {
+			t.Fatalf("model_id = %q, want m", res.ModelID)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("backend calls = %d, want 1 (cached)", got)
+	}
+}
+
+// A backend 404 is the definitive not-found and must surface as ErrModelNotFound.
+func TestResolveNotFoundIsDefinitive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	if _, err := r.Resolve(context.Background(), "ghost", ""); !errors.Is(err, ErrModelNotFound) {
+		t.Fatalf("err = %v, want ErrModelNotFound", err)
+	}
+}
+
+// A transient backend failure (5xx) after a prior success is absorbed by serving
+// the last-known-good resolution — not surfaced as an error.
+func TestResolveStaleServeOnTransient(t *testing.T) {
+	var fail int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.LoadInt32(&fail) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(okBody("m")))
+	}))
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	if _, err := r.Resolve(context.Background(), "m", ""); err != nil {
+		t.Fatalf("prime failed: %v", err)
+	}
+	r.cache.Delete("m:") // expire the fresh cache so the next call re-fetches
+	atomic.StoreInt32(&fail, 1)
+
+	res, err := r.Resolve(context.Background(), "m", "")
+	if err != nil {
+		t.Fatalf("expected last-known-good serve, got error: %v", err)
+	}
+	if res.ModelID != "m" {
+		t.Fatalf("model_id = %q, want m", res.ModelID)
+	}
+}
+
+// A transient failure with no last-known-good returns an error, but NOT
+// ErrModelNotFound — so the handler maps it to a retryable 503, not a 404.
+func TestResolveTransientWithoutCacheIsNotNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	_, err := r.Resolve(context.Background(), "m", "")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if errors.Is(err, ErrModelNotFound) {
+		t.Fatal("transient failure must not be ErrModelNotFound")
+	}
+}
+
+// A transient failure on the first attempt is retried once; a success on the
+// retry resolves cleanly.
+func TestResolveRetryThenSucceed(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(okBody("m")))
+	}))
+	defer srv.Close()
+
+	r := newTestResolver(srv.URL)
+	res, err := r.Resolve(context.Background(), "m", "")
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if res.ModelID != "m" {
+		t.Fatalf("model_id = %q, want m", res.ModelID)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("backend calls = %d, want 2 (one retry)", got)
+	}
+}

--- a/proxy/internal/server/anthropic_handler.go
+++ b/proxy/internal/server/anthropic_handler.go
@@ -62,9 +62,7 @@ func (h *AnthropicHandler) Messages(w http.ResponseWriter, r *http.Request) {
 	tier := r.Header.Get("X-LLM-Tier")
 	resolved, err := h.resolver.Resolve(r.Context(), req.Model, tier)
 	if err != nil {
-		slog.Warn("model resolve failed", "model", req.Model, "error", err)
-		WriteError(w, "anthropic", http.StatusNotFound, "not_found", fmt.Sprintf("Model '%s' not found or not available", req.Model))
-		metrics.ErrorsTotal.WithLabelValues("anthropic", "routing").Inc()
+		writeResolveError(w, "anthropic", req.Model, err)
 		return
 	}
 

--- a/proxy/internal/server/errors.go
+++ b/proxy/internal/server/errors.go
@@ -2,7 +2,13 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
+
+	"github.com/thinkube/thinkube-control/proxy/internal/metrics"
+	"github.com/thinkube/thinkube-control/proxy/internal/resolver"
 )
 
 type anthropicError struct {
@@ -19,6 +25,24 @@ type openaiError struct {
 		Type    string `json:"type"`
 		Code    string `json:"code"`
 	} `json:"error"`
+}
+
+// writeResolveError maps a resolver failure to the right client response.
+// Only a definitive ErrModelNotFound is a 404; every other (transient) failure
+// is a retryable 503 — so a momentary backend stall/flap is never surfaced as
+// "model not found".
+func writeResolveError(w http.ResponseWriter, protocol, model string, err error) {
+	if errors.Is(err, resolver.ErrModelNotFound) {
+		slog.Warn("model not found", "model", model, "error", err)
+		WriteError(w, protocol, http.StatusNotFound, "not_found",
+			fmt.Sprintf("Model '%s' not found", model))
+		metrics.ErrorsTotal.WithLabelValues(protocol, "not_found").Inc()
+		return
+	}
+	slog.Warn("model resolve unavailable", "model", model, "error", err)
+	WriteError(w, protocol, http.StatusServiceUnavailable, "service_unavailable",
+		fmt.Sprintf("Model '%s' is temporarily unavailable, please retry", model))
+	metrics.ErrorsTotal.WithLabelValues(protocol, "resolve_unavailable").Inc()
 }
 
 func WriteError(w http.ResponseWriter, protocol string, statusCode int, errorType string, message string) {

--- a/proxy/internal/server/openai_handler.go
+++ b/proxy/internal/server/openai_handler.go
@@ -58,9 +58,7 @@ func (h *OpenAIHandler) ChatCompletions(w http.ResponseWriter, r *http.Request) 
 	tier := r.Header.Get("X-LLM-Tier")
 	resolved, err := h.resolver.Resolve(r.Context(), req.Model, tier)
 	if err != nil {
-		slog.Warn("model resolve failed", "model", req.Model, "error", err)
-		WriteError(w, "openai", http.StatusNotFound, "not_found", fmt.Sprintf("Model '%s' not found or not available", req.Model))
-		metrics.ErrorsTotal.WithLabelValues("openai", "routing").Inc()
+		writeResolveError(w, "openai", req.Model, err)
 		return
 	}
 
@@ -210,9 +208,7 @@ func (h *OpenAIHandler) Embeddings(w http.ResponseWriter, r *http.Request) {
 	tier := r.Header.Get("X-LLM-Tier")
 	resolved, err := h.resolver.Resolve(r.Context(), req.Model, tier)
 	if err != nil {
-		slog.Warn("embedding model resolve failed", "model", req.Model, "error", err)
-		WriteError(w, "openai", http.StatusNotFound, "not_found", fmt.Sprintf("Model '%s' not found or not available", req.Model))
-		metrics.ErrorsTotal.WithLabelValues("openai", "routing").Inc()
+		writeResolveError(w, "openai", req.Model, err)
 		return
 	}
 

--- a/proxy/internal/server/server.go
+++ b/proxy/internal/server/server.go
@@ -60,8 +60,11 @@ func (s *Server) registerRoutes() {
 		}()
 	}
 
-	// Resolver and forwarder
+	// Resolver and forwarder. The resolver keeps a locally-synced snapshot of the
+	// control plane's resolution table so the request path resolves in-memory
+	// instead of calling the control plane per request.
 	res := resolver.New(s.cfg.BackendURL, s.cfg.ModelAliases)
+	res.StartSnapshotSync(context.Background())
 	fwd := forwarder.New(s.cfg.RequestTimeout)
 
 	// OpenAI handler


### PR DESCRIPTION
Snapshot-first LLM model resolution so the inference data path no longer depends on the control plane per request. Closes SP-tgnbej (implements TEP-tgnbb3).

## Slices
- **SP-tgnbej_SL-1** — gateway resolver resilience: retry-once + last-known-good; classify a backend 404 as definitive (client 404) vs transient (retryable 503); shared `writeResolveError` at all resolve sites; retry/stale-serve metric.
- **SP-tgnbej_SL-2** — snapshot-first resolution: in-memory `GET /api/v1/llm/models/resolve-all` bulk endpoint + a proxy background-sync goroutine + snapshot-first `Resolve` (hit → no control-plane call; miss → live fallback; unknown → 404); snapshot/live source metric.
- **SP-tgnbej_SL-3** — backend event-loop hygiene: throttle the cluster-resources refresh (15s→60s) and replace the typed ~336-pod deserialization with a bounded raw-JSON parse (`_preload_content=False` + server-side phase filter), removing the periodic stall that timed out resolve and tripped the liveness probe.

## How to verify
- Proxy: `cd proxy && go build ./... && go vet ./... && go test ./...` (resolver suite incl. snapshot hit→0 live calls, miss→1, last-known-good, classification; race-clean).
- Backend: `cd backend && pytest tests/test_llm_resolve_all.py tests/test_cluster_resources_throttle.py` (in-cluster test env).
- Post-deploy smoke (non-gating, TEP-tgnvkw): run the multi-agent debate under concurrent load; confirm no spurious 404 and no backend liveness restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)