### PR TITLE
Expose async notebook execution (submit + poll) over MCP

### DIFF
--- a/backend/app/api/jupyter_notebooks.py
+++ b/backend/app/api/jupyter_notebooks.py
@@ -18,7 +18,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 
@@ -420,4 +420,54 @@ async def jupyter_execute_all_cells(
     result = await _proxy_tool_call("execute_all_cells", {
         "notebook_path": request.notebook_path,
     })
+    return ToolResultResponse(result=result)
+
+
+# Submit + poll for long-running cells. The blocking execute tools hold the
+# request open until the cell finishes, which times out the MCP bridge on
+# multi-minute cells. These expose the tk-ai-extension's async submit/poll tools
+# (already registered there): submit returns an execution_id immediately, then
+# poll status. Both return fast, so they use a short timeout, never the 300s
+# blocking default. Like the blocking tools these are frontend-delegated, so the
+# proxy passes notebook_path/cell_index only — the frontend supplies the kernel.
+_ASYNC_PROXY_TIMEOUT = 30.0
+
+
+@router.post("/execute-cell-async", response_model=ToolResultResponse, operation_id="jupyter_execute_cell_async")
+async def jupyter_execute_cell_async(
+    request: CellExecuteRequest,
+    current_user: dict = Depends(get_current_user_dual_auth),
+):
+    """Start executing a code cell without blocking; returns an execution_id.
+
+    Use for long-running cells. Poll completion with jupyter_check_execution_status.
+    """
+    result = await _proxy_tool_call("execute_cell_async", {
+        "notebook_path": request.notebook_path,
+        "cell_index": int(request.cell_index),
+    }, timeout=_ASYNC_PROXY_TIMEOUT)
+    return ToolResultResponse(result=result)
+
+
+@router.get("/execution-status", response_model=ToolResultResponse, operation_id="jupyter_check_execution_status")
+async def jupyter_check_execution_status(
+    execution_id: str = Query(..., description="Execution ID returned by jupyter_execute_cell_async"),
+    current_user: dict = Depends(get_current_user_dual_auth),
+):
+    """Poll an async cell execution: returns running / completed / error and outputs."""
+    result = await _proxy_tool_call("check_execution_status", {
+        "execution_id": execution_id,
+    }, timeout=_ASYNC_PROXY_TIMEOUT)
+    return ToolResultResponse(result=result)
+
+
+@router.get("/all-cells-status", response_model=ToolResultResponse, operation_id="jupyter_check_all_cells_status")
+async def jupyter_check_all_cells_status(
+    execution_id: str = Query(..., description="Execution ID returned by jupyter_execute_all_cells"),
+    current_user: dict = Depends(get_current_user_dual_auth),
+):
+    """Poll an async run-all execution (jupyter_execute_all_cells returns an execution_id)."""
+    result = await _proxy_tool_call("check_all_cells_status", {
+        "execution_id": execution_id,
+    }, timeout=_ASYNC_PROXY_TIMEOUT)
     return ToolResultResponse(result=result)

--- a/backend/tests/test_jupyter_async_exec.py
+++ b/backend/tests/test_jupyter_async_exec.py
@@ -1,0 +1,64 @@
+"""Async notebook execution exposed over MCP: submit + poll (SP-tgo0u1 SL-1).
+
+Deterministic unit tests with _proxy_tool_call mocked — assert each endpoint
+proxies the right tk-ai-extension tool with the right args and a short timeout,
+and that the blocking endpoints are unchanged.
+"""
+
+import asyncio
+
+import app.api.jupyter_notebooks as jn
+from app.api.jupyter_notebooks import CellExecuteRequest
+
+
+def _patch_proxy(monkeypatch):
+    calls = []
+
+    async def rec(tool_name, arguments, timeout=300.0):
+        calls.append({"tool": tool_name, "args": arguments, "timeout": timeout})
+        return {"ok": True}
+
+    monkeypatch.setattr(jn, "_proxy_tool_call", rec)
+    return calls
+
+
+def test_execute_cell_async_submits_nonblocking(monkeypatch):
+    calls = _patch_proxy(monkeypatch)
+    asyncio.run(jn.jupyter_execute_cell_async(
+        CellExecuteRequest(cell_index="5", notebook_path="nb.ipynb"), current_user={}))
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["tool"] == "execute_cell_async"
+    assert c["args"] == {"notebook_path": "nb.ipynb", "cell_index": 5}
+    # Submit returns immediately -> short timeout, NOT the 300s blocking default.
+    assert c["timeout"] == jn._ASYNC_PROXY_TIMEOUT
+    assert c["timeout"] < 300.0
+
+
+def test_check_execution_status_polls(monkeypatch):
+    calls = _patch_proxy(monkeypatch)
+    asyncio.run(jn.jupyter_check_execution_status(execution_id="abc", current_user={}))
+    c = calls[0]
+    assert c["tool"] == "check_execution_status"
+    assert c["args"] == {"execution_id": "abc"}
+    assert c["timeout"] == jn._ASYNC_PROXY_TIMEOUT
+
+
+def test_check_all_cells_status_polls(monkeypatch):
+    calls = _patch_proxy(monkeypatch)
+    asyncio.run(jn.jupyter_check_all_cells_status(execution_id="xyz", current_user={}))
+    c = calls[0]
+    assert c["tool"] == "check_all_cells_status"
+    assert c["args"] == {"execution_id": "xyz"}
+    assert c["timeout"] == jn._ASYNC_PROXY_TIMEOUT
+
+
+def test_blocking_execute_cell_unchanged(monkeypatch):
+    calls = _patch_proxy(monkeypatch)
+    asyncio.run(jn.jupyter_execute_cell(
+        CellExecuteRequest(cell_index="2", notebook_path="nb.ipynb"), current_user={}))
+    c = calls[0]
+    assert c["tool"] == "execute_cell"
+    assert c["args"] == {"notebook_path": "nb.ipynb", "cell_index": 2}
+    # Blocking path keeps the 300s default (no short-timeout override).
+    assert c["timeout"] == 300.0

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,3 +1,4 @@
 .Control Plane
 * xref:index.adoc[thinkube-control]
 * xref:llm-serving.adoc[LLM serving & models]
+* xref:notebooks.adoc[Notebook execution over MCP]

--- a/docs/modules/ROOT/pages/notebooks.adoc
+++ b/docs/modules/ROOT/pages/notebooks.adoc
@@ -1,0 +1,40 @@
+= Notebook execution over MCP
+
+thinkube-control exposes JupyterHub notebooks as MCP tools (backed by the
+tk-ai-extension running in the notebook server), so an agent can list, read,
+edit, and execute cells.
+
+== Executing cells
+
+[horizontal]
+`jupyter_execute_cell`:: Execute one cell and wait for its result. Best for
+  short cells — the call blocks until the cell finishes.
+`jupyter_execute_all_cells`:: Run the whole notebook. Returns an `execution_id`
+  immediately (it runs asynchronously).
+
+== Long-running cells: submit and poll
+
+Blocking execution holds the request open until the cell completes. For a cell
+that runs for minutes (a multi-agent run, model training, a long query) that
+exceeds the MCP bridge / proxy timeout and the call fails *even though the cell
+keeps running in the kernel*. Use the asynchronous **submit-then-poll** tools
+instead — the request never stays open:
+
+[horizontal]
+`jupyter_execute_cell_async`:: Start a cell without blocking. Returns an
+  `execution_id` immediately.
+`jupyter_check_execution_status`:: Poll an `execution_id`; returns
+  `running` / `completed` / `error` and the outputs once finished.
+`jupyter_check_all_cells_status`:: Poll a run-all `execution_id` returned by
+  `jupyter_execute_all_cells`.
+
+Pattern:
+
+. `jupyter_execute_cell_async(notebook_path, cell_index)` → `execution_id`
+. poll `jupyter_check_execution_status(execution_id)` until `status` is
+  `completed` (or `error`)
+. read the returned outputs
+
+Rule of thumb: if a cell might run longer than a few seconds, launch it with
+`jupyter_execute_cell_async` and poll, rather than the blocking
+`jupyter_execute_cell`.


### PR DESCRIPTION
Exposes the tk-ai-extension's already-registered async execution tools through thinkube-control so long notebook cells don't time out the MCP bridge. Closes SP-tgo0u1 (implements TEP-tgo0ri).

## Slice
- **SP-tgo0u1_SL-1** — three thin passthroughs in `jupyter_notebooks.py`: `jupyter_execute_cell_async` (returns an `execution_id` immediately), `jupyter_check_execution_status`, `jupyter_check_all_cells_status` — short timeout, not the 300s blocking default. Frontend-delegated like the blocking tools (proxy passes notebook_path/cell_index; the frontend supplies the kernel). Blocking endpoints unchanged. Unit test (mocked `_proxy_tool_call`) + a docs page on submit-and-poll.

## How to verify
- `cd backend && pytest tests/test_jupyter_async_exec.py` (in-cluster CI env).
- Post-deploy smoke (non-gating): launch a long cell via `jupyter_execute_cell_async`, confirm an immediate `execution_id`, then `jupyter_check_execution_status` polls running → completed with outputs — no bridge timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)